### PR TITLE
Fix control not being passed in some cases & refresh form data when being given control

### DIFF
--- a/src/Forms/Components/GazeBanner.php
+++ b/src/Forms/Components/GazeBanner.php
@@ -91,8 +91,7 @@ class GazeBanner extends Component
             $this->registerListeners([
                 'FilamentGaze::takeControl' => [
                     function () {
-                        // Very hacky, maybe a better solution for this?
-                        $this->getLivewire()->mount($this->getLivewire()->getForm('form')->getRecord()?->id);
+                        $this->refreshForm();
                         $this->takeControl();
                     },
                 ],
@@ -141,6 +140,12 @@ class GazeBanner extends Component
         }
 
         return $this->identifier;
+    }
+
+    public function refreshForm()
+    {
+        // Very hacky, maybe a better solution for this?
+        $this->getLivewire()->mount($this->getLivewire()->getForm('form')->getRecord()?->id);
     }
 
     /**


### PR DESCRIPTION
This PR does 3 things:

- Handles some cases where the form would have no controller. This would happen when the controller naturally left the form and there were 3+ people viewing it.
- Refresh form when being given natural control. To resolve #2 .
- Scope `auth()->id()` to the correct guard in some places.