### PR TITLE
Feature - `->hideOnCreate()` helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ GazeBanner::make()
 GazeBanner::make()
     ->hidden(fn (?Order $record) => $record === null),
 ```
+There is also a helper function
+```php
+GazeBanner::make()
+    ->hideOnCreate(),
+```
 
 
 ## Docs
@@ -125,6 +130,11 @@ GazeBanner::make()
 
 #### Arguments
 `fnc` - (optional, closure | bool) If the user can take control of the resource. Default is true. If a closure is passed, it should return a bool.
+
+### `->hideOnCreate()`
+
+#### Description
+`hideOnCreate` is a helper function that can be used to hide the banner on create forms.
 
 
 ## Author

--- a/src/Forms/Components/GazeBanner.php
+++ b/src/Forms/Components/GazeBanner.php
@@ -101,6 +101,17 @@ class GazeBanner extends Component
         return $this;
     }
 
+    /*
+     *  Helper function to hide on create
+     */
+
+    public function hideOnCreate(): static
+    {
+        $this->hidden(fn ($record) => $record === null);
+
+        return $this;
+    }
+
     /**
      * Set the take control state
      */


### PR DESCRIPTION
This PR does the following:
- Adds a `->hideOnCreate()` helper function that wraps the docs example for hiding the banner on create forms.
- Adds docs explaining the helper function.
- 
This PR will satisfy #4.