### PR TITLE
Fix - get the route key from models

### DIFF
--- a/src/Forms/Components/GazeBanner.php
+++ b/src/Forms/Components/GazeBanner.php
@@ -157,7 +157,11 @@ class GazeBanner extends Component
     public function refreshForm()
     {
         // Very hacky, maybe a better solution for this?
-        $this->getLivewire()->mount($this->getRecord()?->id);
+	    $record = $this->getRecord();
+
+	    if ($record) {
+            $this->getLivewire()->mount($record->{$record->getRouteKeyName()});
+	    } 
     }
 
     /**


### PR DESCRIPTION
For resource models using a custom route key with the `getRouteKeyName` method the GazeBanner isbroken as it explicitly uses id as the key.

This PR satisfies #7 