### PR TITLE
fix icon aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ GazeBanner::make()
 #### Description
 `hideOnCreate` is a helper function that can be used to hide the banner on create forms.
 
+## Customization
+
+### Change icons
+
+To [customize the icons](https://filamentphp.com/docs/3.x/support/icons#replacing-the-default-icons) in the banner, you may use the following aliases:
+
+- `filament-gaze::banner.locked` for the lock icon
+- `filament-gaze::banner.view` for the eye icon
 
 ## Author
 

--- a/resources/views/forms/components/gaze-banner.blade.php
+++ b/resources/views/forms/components/gaze-banner.blade.php
@@ -9,13 +9,13 @@
                 <div class="flex flex-col justify-center">
                     @if($isLockable && !$hasControl)
                         <x-filament::icon
-                            alias="panels::filament-gaze.banner.icon"
+                            alias="filament-gaze::banner.locked"
                             icon="heroicon-m-lock-closed"
                             class="h-5 w-5 my-auto"
                         />
                     @else
                         <x-filament::icon
-                            alias="panels::filament-gaze.banner.icon"
+                            alias="filament-gaze::banner.view"
                             icon="heroicon-m-eye"
                             class="h-5 w-5 my-auto"
                         />


### PR DESCRIPTION
To be able to customize the icons, the alias names must be distinguishable. I have also included a note on this in the readme.