### PR TITLE
Add GazeLockControl Trait to extend control functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ GazeBanner::make()
     ->hideOnCreate(),
 ```
 ### Hide actions based on the controlling user (if you've implemented the take control logic)
+
+You will need to use the `DiscoveryDesign\FilamentGaze\Traits\GazeLockControl` trait, in order to access the method.
 ```php
 namespace App\Filament\Resources\CustomerResource\Pages;
 
@@ -163,7 +165,7 @@ class EditCustomer extends EditRecord
 ### `->hasGazeControl()`
 
 #### Description
-`hasGazeControl` is a helper function that can be used to hide actions, and is usable from the GazeLocKControl trait.
+`hasGazeControl` is a helper function that can be used to hide actions, and is usable from the GazeLockControl trait.
 
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -97,7 +97,29 @@ There is also a helper function
 GazeBanner::make()
     ->hideOnCreate(),
 ```
+### Hide actions based on the controlling user (if you've implemented the take control logic)
+```php
+namespace App\Filament\Resources\CustomerResource\Pages;
 
+use App\Filament\Resources\CustomerResource;
+use DiscoveryDesign\FilamentGaze\Traits\GazeLockControl;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditCustomer extends EditRecord
+{
+    use GazeLockControl;
+
+    protected static string $resource = CustomerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make()->hidden(!$this->hasGazeControl()),
+        ];
+    }
+
+```
 
 ## Docs
 
@@ -137,6 +159,12 @@ GazeBanner::make()
 
 #### Description
 `hideOnCreate` is a helper function that can be used to hide the banner on create forms.
+
+### `->hasGazeControl()`
+
+#### Description
+`hasGazeControl` is a helper function that can be used to hide actions, and is usable from the GazeLocKControl trait.
+
 
 ## Customization
 

--- a/src/Forms/Components/GazeBanner.php
+++ b/src/Forms/Components/GazeBanner.php
@@ -143,7 +143,7 @@ class GazeBanner extends Component
 
     }
 
-    public function refreshForm()
+    public function refreshForm(): void
     {
         // Very hacky, maybe a better solution for this?
 	    $record = $this->getRecord();
@@ -161,7 +161,7 @@ class GazeBanner extends Component
      *
      * @return void
      */
-    public function refreshViewers()
+    public function refreshViewers(): void
     {
         $this->registerListeners([
             'FilamentGaze::takeControl' => [

--- a/src/Forms/Components/GazeBanner.php
+++ b/src/Forms/Components/GazeBanner.php
@@ -4,10 +4,10 @@ namespace DiscoveryDesign\FilamentGaze\Forms\Components;
 
 use Carbon\Carbon;
 use Closure;
-use DiscoveryDesign\FilamentGaze\Traits\GazeLockControl;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Facades\Cache;
+use DiscoveryDesign\FilamentGaze\Traits\GazeLockControl;
 
 /**
  * Class GazeBanner

--- a/src/Forms/Components/GazeBanner.php
+++ b/src/Forms/Components/GazeBanner.php
@@ -4,6 +4,7 @@ namespace DiscoveryDesign\FilamentGaze\Forms\Components;
 
 use Carbon\Carbon;
 use Closure;
+use DiscoveryDesign\FilamentGaze\Traits\GazeLockControl;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Component;
 use Illuminate\Support\Facades\Cache;
@@ -18,6 +19,7 @@ use Illuminate\Support\Facades\Cache;
  */
 class GazeBanner extends Component
 {
+    use GazeLockControl;
     /**
      * The array of current viewers.
      */
@@ -63,7 +65,7 @@ class GazeBanner extends Component
     public function identifier(string | Closure $fnc = ''): static
     {
         $this->identifier = (string) $this->evaluate($fnc);
-
+        Cache::put('filament-gaze-' . $this->getIdentifier() . '-custom-identfier',$this->identifier);
         return $this;
     }
 
@@ -139,20 +141,6 @@ class GazeBanner extends Component
 
         Cache::put('filament-gaze-' . $identifier, $curViewers, now()->addSeconds(max([5, $this->pollTimer * 2])));
 
-    }
-
-    public function getIdentifier()
-    {
-        if (! $this->identifier) {
-            $record = $this->getRecord();
-            if (! $record) {
-                $this->identifier = (string) $this->getModel();
-            } else {
-                $this->identifier = get_class($record) . '-' . $record->id;
-            }
-        }
-
-        return $this->identifier;
     }
 
     public function refreshForm()

--- a/src/Traits/GazeLockControl.php
+++ b/src/Traits/GazeLockControl.php
@@ -26,6 +26,7 @@ trait GazeLockControl {
                 $this->identifier = get_class($record) . '-' . $record->id;
             }
         }
+        // Ensure there's not a custom identifier set.
         $customIdentifier = Cache::get('filament-gaze-' . $this->identifier . '-custom-identfier');
         if($customIdentifier) {
             $this->identifier = $customIdentifier;
@@ -33,14 +34,15 @@ trait GazeLockControl {
         return $this->identifier;
     }
 
-    public function setControllingUser(string|int $userId): void
-    {
-        Cache::put('filament-gaze-controller-' .$this->getIdentifier(), $userId,now()->addSeconds(max([5, $this->pollTimer * 2])));
-
-    }
-
+    /**
+     * See if current user has gaze control access.
+     * @return bool
+     */
     public function hasGazeControl(): bool
     {
+        if(!isset(request()->user()?->id)){
+            return false;
+        }
         $currentViewers = Cache::get('filament-gaze-' . $this->getIdentifier());
         if( is_null($currentViewers) ) {
             return false;

--- a/src/Traits/GazeLockControl.php
+++ b/src/Traits/GazeLockControl.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace DiscoveryDesign\FilamentGaze\Traits;
+
+
+use Illuminate\Support\Facades\Cache;
+/**
+ * Trait GazeLockControl
+ *
+ * This Trait can be used by pages etc to control button access, and is used to contain the identifier logic.
+ */
+trait GazeLockControl {
+    /**
+     * The custom identifier for the GazeBanner component.
+     */
+    public ?string $identifier = null;
+
+    public function getIdentifier(): ?string
+    {
+        // Try to get the custom identifier first, if one has been set.
+        if (! $this->identifier) {
+            $record = $this->getRecord();
+            if (! $record) {
+                $this->identifier = (string) $this->getModel();
+            } else {
+                $this->identifier = get_class($record) . '-' . $record->id;
+            }
+        }
+        $customIdentifier = Cache::get('filament-gaze-' . $this->identifier . '-custom-identfier');
+        if($customIdentifier) {
+            $this->identifier = $customIdentifier;
+        }
+        return $this->identifier;
+    }
+
+    public function setControllingUser(string|int $userId): void
+    {
+        Cache::put('filament-gaze-controller-' .$this->getIdentifier(), $userId);
+
+    }
+
+    public function hasControl(): bool
+    {
+        $currentViewers = Cache::get('filament-gaze-' . $this->getIdentifier());
+        if( is_null($currentViewers) ) {
+            return false;
+        }
+        foreach ($currentViewers as $viewer) {
+            if($viewer['id'] === request()->user()->id && $viewer['has_control']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/src/Traits/GazeLockControl.php
+++ b/src/Traits/GazeLockControl.php
@@ -2,8 +2,9 @@
 
 namespace DiscoveryDesign\FilamentGaze\Traits;
 
-
 use Illuminate\Support\Facades\Cache;
+
+
 /**
  * Trait GazeLockControl
  *

--- a/src/Traits/GazeLockControl.php
+++ b/src/Traits/GazeLockControl.php
@@ -35,11 +35,11 @@ trait GazeLockControl {
 
     public function setControllingUser(string|int $userId): void
     {
-        Cache::put('filament-gaze-controller-' .$this->getIdentifier(), $userId);
+        Cache::put('filament-gaze-controller-' .$this->getIdentifier(), $userId,now()->addSeconds(max([5, $this->pollTimer * 2])));
 
     }
 
-    public function hasControl(): bool
+    public function hasGazeControl(): bool
     {
         $currentViewers = Cache::get('filament-gaze-' . $this->getIdentifier());
         if( is_null($currentViewers) ) {

--- a/src/Traits/GazeLockControl.php
+++ b/src/Traits/GazeLockControl.php
@@ -44,8 +44,9 @@ trait GazeLockControl {
             return false;
         }
         $currentViewers = Cache::get('filament-gaze-' . $this->getIdentifier());
+
         if( is_null($currentViewers) ) {
-            return false;
+            return true;
         }
         foreach ($currentViewers as $viewer) {
             if($viewer['id'] === request()->user()->id && $viewer['has_control']) {


### PR DESCRIPTION
This adds a new Trait called `GazeLockControl` 

The idea is it extends the functionality of the plugin so you easily see if the current user is the controlling user and define what is hidden in your pages etc based on that logic.  

This isn't forced etc, so is up to the user to implement if they want the logic.

For example, take the below, I have an Edit Customer page, where I only want users controlling the page to have the ability to save / delete.  

This is something I also saw via #26 so thought I'd give it a whirl at implementing.

Below is an example of how it works in this use case - for example an Edit page:
```php 
class EditCustomer extends EditRecord
{
    use GazeLockControl;

    protected static string $resource = CustomerResource::class;

    protected function getHeaderActions(): array
    {
        return [
            Actions\DeleteAction::make()->hidden(!$this->hasGazeControl()),
        ];
    }

    protected function getFormActions(): array
    {
        return [
            Actions\Action::make('Save')->action('save')->hidden(!$this->hasGazeControl()),
        ];
    }
}

```

Here's a Loom of how it works also: 
https://www.loom.com/share/f8c66721ff934ea8bba86be8d39af7bc?sid=21cb0f9c-8eb1-47ba-a18b-b6ffe446939c 

Let me know if there's any adjustments needed 👍🏻 
